### PR TITLE
From lxde/qtermwidget@60221da by @yan12125: Support ECMA-48 REP

### DIFF
--- a/src/Screen.h
+++ b/src/Screen.h
@@ -221,6 +221,11 @@ public:
      */
     void insertChars(int n);
     /**
+     * Repeat the preceeding graphic character @n times, including SPACE.
+     * If @n is 0 then the character is repeated once.
+     */
+    void repeatChars(int n);
+    /**
      * Removes @p n lines beginning from the current cursor position.
      * The position of the cursor is not altered.
      * If @p n is 0 then one line is removed.
@@ -717,6 +722,9 @@ private:
 
     // last position where we added a character
     int _lastPos;
+
+    // used in REP (repeating char)
+    unsigned short _lastDrawnChar;
 };
 
 }

--- a/src/Vt102Emulation.cpp
+++ b/src/Vt102Emulation.cpp
@@ -240,7 +240,7 @@ void Vt102Emulation::initTokenizer()
     for (i = 32; i < 256; ++i) {
         charClass[i] |= CHR;
     }
-    for (s = (quint8 *)"@ABCDGHILMPSTXZcdfry"; *s != 0u; ++s) {
+    for (s = (quint8 *)"@ABCDGHILMPSTXZbcdfry"; *s != 0u; ++s) {
         charClass[*s] |= CPN;
     }
     // resize = \e[8;<row>;<col>t
@@ -684,6 +684,7 @@ void Vt102Emulation::processToken(int token, int p, int q)
     case TY_CSI_PN('T'      ) : _currentScreen->scrollDown           (p         ); break;
     case TY_CSI_PN('X'      ) : _currentScreen->eraseChars           (p         ); break;
     case TY_CSI_PN('Z'      ) : _currentScreen->backtab              (p         ); break;
+    case TY_CSI_PN('b'      ) : _currentScreen->repeatChars          (p         ); break;
     case TY_CSI_PN('c'      ) :      reportTerminalType   (          ); break; //VT100
     case TY_CSI_PN('d'      ) : _currentScreen->setCursorY           (p         ); break; //LINUX
     case TY_CSI_PN('f'      ) : _currentScreen->setCursorYX          (p,      q); break; //VT100


### PR DESCRIPTION
From lxde/qtermwidget@60221da by @yan12125: Support ECMA-48 REP. I tried to make the changes follow existing styles and conventions.

[ECMA-48](http://www.ecma-international.org/publications/files/ECMA-ST/Ecma-048.pdf) 8.3.103 describes the sequence **CSI P<sub>n</sub> b** for repeating the previous character in the data stream. This sequence has been present in [XTerm](http://invisible-island.net/xterm/ctlseqs/ctlseqs.pdf) since [January 1997](https://invisible-mirror.net/ncurses/ncurses.faq.html#xterm_generic-id) and has been [added to the latest `terminfo` entry](https://invisible-mirror.net/ncurses/terminfo.src.html#t20170729) for `xterm-new` and derived entries such as `xterm-256color`.