### PR TITLE
Fixed bug 406828

### DIFF
--- a/src/ViewContainer.cpp
+++ b/src/ViewContainer.cpp
@@ -543,7 +543,9 @@ void TabbedViewContainer::setTabActivity(int index, bool activity)
 void TabbedViewContainer::updateActivity(ViewProperties *item)
 {
     auto controller = qobject_cast<SessionController*>(item);
-    auto index = indexOf(controller->view());
+    auto topLevelSplitter = qobject_cast<ViewSplitter*>(controller->view()->parentWidget())->getToplevelSplitter();
+
+    const int index = indexOf(topLevelSplitter);
     if (index != currentIndex()) {
         setTabActivity(index, true);
     }


### PR DESCRIPTION
This commit fixes bug 406828. Activity in any of the split panes of an inactive tab will now highlight the name of this tab.