### PR TITLE
Changed 'Defaults' texts on reset buttons to 'Reset'

### DIFF
--- a/src/widgets/EditProfileAppearancePage.ui
+++ b/src/widgets/EditProfileAppearancePage.ui
@@ -96,7 +96,7 @@
               <string>Reset the selected color scheme settings to the default values</string>
              </property>
              <property name="text">
-              <string>Defaults</string>
+              <string>Reset</string>
              </property>
             </widget>
            </item>

--- a/src/widgets/EditProfileKeyboardPage.ui
+++ b/src/widgets/EditProfileKeyboardPage.ui
@@ -102,7 +102,7 @@
            <string>Reset the selected key bindings scheme to its default values</string>
           </property>
           <property name="text">
-           <string>Defaults</string>
+           <string>Reset</string>
           </property>
          </widget>
         </item>


### PR DESCRIPTION
In the UI of Konsole, when editing a keyboard setting of a profile, there is a
'Defaults' button, which resets everything back to an initial state. However,
'Reset' covers its purpose more intuitively, in line with the KDE guideline on
intuitiveness and ease of use. Also, the original can be misinterpreted as:
'Make this the new defaults' instead of 'Reset to original defaults'. Hence the change.

Screenshot of what its about:

![konsole_defaults_button](https://user-images.githubusercontent.com/2974380/108128205-af242700-70ac-11eb-8ee0-27a677bdbf16.png)

NOTE: THIS IS NOT TESTED! However, given its a text-only change, it should not break anything. Also, I did not want to setup the entire KDE develeopment environment for a trivial change such as this. And it could also be that other locations/programs could benefit from this change, but I don't know about them.

PS: My first contribution to open source, yay! :)
