### PR TITLE
handle tertiary device attributes request with DECRPTUI

### DIFF
--- a/src/Vt102Emulation.h
+++ b/src/Vt102Emulation.h
@@ -139,6 +139,7 @@ private:
     void processSessionAttributeRequest(int tokenSize);
 
     void reportTerminalType();
+    void reportTertiaryAttributes();
     void reportSecondaryAttributes();
     void reportStatus();
     void reportAnswerBack();


### PR DESCRIPTION
In the course of work on https://github.com/dankamongmen/notcurses/issues/1807, I determine that Konsole doesn't respond to Send Tertiary Device Attributes requests. Handle it in `Vt102Emulation.cpp`, responding with the same all-zeroes response that XTerm currently returns.

I tested that I now get the expected and well-formed DECRPTUI message upon delivery of a DAR3 using `notcurses-info`.

With that said, I'm still seeing the `0c` on output, so I think this PR might be somehow incomplete? Please advise. Thanks!