### PR TITLE
Be able to resize the splits to the same size.

### DIFF
--- a/desktop/konsoleui.rc
+++ b/desktop/konsoleui.rc
@@ -25,6 +25,7 @@
                 <Action name="expand-active-view"/>
                 <Action name="shrink-active-view"/>
                 <Action name="toggle-maximize-current-view"/>
+                <Action name="equal-size-view"/>
             </Menu>
             <Separator/>
             <Action name="detach-tab" />

--- a/doc/manual/index.docbook
+++ b/doc/manual/index.docbook
@@ -695,6 +695,14 @@ Any output on one view is duplicated in the other view.
 </para></listitem>
 </varlistentry>
 
+<varlistentry>
+<term><menuchoice>
+<shortcut><keycombo action="simul">&Ctrl;&Shift;<keycap>\</keycap></keycombo></shortcut>
+<guimenu>View</guimenu><guisubmenu>Split View</guisubmenu><guimenuitem>Equal size to all views</guimenuitem></menuchoice>
+</term>
+<listitem><para><action>Sets the same size for all views</action>
+</para></listitem>
+</varlistentry>
 
 <varlistentry>
 <term><menuchoice>

--- a/src/ViewManager.h
+++ b/src/ViewManager.h
@@ -318,6 +318,7 @@ private Q_SLOTS:
     void splitTopBottom();
     void expandActiveContainer();
     void shrinkActiveContainer();
+    void equalSizeAllContainers();
 
     // called when the "Detach View" menu item is selected
     void detachActiveView();


### PR DESCRIPTION
Here how it looks like: https://imgur.com/a/uaMQvT6 (better quality: https://xutaxkamay.com/videos/konsole_equalsize.mp4)

Before, it was impossible to resize the splits
with the same size in case they were manually resized.

I have added a new button menu for doing so:
in View -> Split View -> Equal size to all views.

First I wanted to make this as a plugin,
but since I thought it could make splits a bit more useful,
I decided to merge it not as a plugin but internally.

GUI: Menu -> View -> Split View -> Equal size to all views
CHANGELOG: Added equal size to all split views.