### PR TITLE
Add `Copy` keyboard shortcut alternate bind to `Ctrl+Ins`

### DIFF
--- a/src/session/SessionController.cpp
+++ b/src/session/SessionController.cpp
@@ -655,7 +655,10 @@ void SessionController::setupCommonActions()
 
     // Copy and Paste
     action = KStandardAction::copy(this, &SessionController::copy, collection);
-    collection->setDefaultShortcut(action, Konsole::ACCEL | Qt::Key_C);
+    QList<QKeySequence> copyShortcut;
+    copyShortcut.append(QKeySequence(Konsole::ACCEL | Qt::Key_C));
+    copyShortcut.append(QKeySequence(Qt::CTRL | Qt::Key_Insert));
+    collection->setDefaultShortcuts(action, copyShortcut);
     // disabled at first, since nothing has been selected now
     action->setEnabled(false);
 


### PR DESCRIPTION
Adds `Ctrl+Insert` as a shortcut to `Copy`; this is an alternate keybinding to `Copy` that works across both KDE and Windows and doesn't conflict with `Ctrl+C` used to terminate terminal programs.