### PR TITLE
fix a minor bug calling hosts that are defined in ~/.ssh/config

### DIFF
--- a/src/plugins/SSHManager/sshmanagerplugin.cpp
+++ b/src/plugins/SSHManager/sshmanagerplugin.cpp
@@ -203,6 +203,14 @@ void SSHManagerPlugin::requestConnection(QSortFilterProxyModel *filterModel,
 
     QString sshCommand = QStringLiteral("ssh ");
     if (data.useSshConfig) {
+        // useSshConfig is defined in sshwidget.ui:165 -> meaning wheather the ssh config is taken from .ssh/config
+        if (!data.name.isEmpty()) {
+            // if we got data.name (which is the profile identifier as in sshmanagermodel.cpp:263
+            sshCommand += data.name;
+        }
+    }
+    if (!data.useSshConfig) {
+        // useSshConfig is false aka not set, so we just a assume a manual profile entry in terms of an entry that was added manually to Konsole
         if (data.sshKey.length()) {
             sshCommand += QStringLiteral("-i %1 ").arg(data.sshKey);
         }
@@ -214,10 +222,10 @@ void SSHManagerPlugin::requestConnection(QSortFilterProxyModel *filterModel,
         if (!data.username.isEmpty()) {
             sshCommand += data.username + QLatin1Char('@');
         }
-    }
-
-    if (!data.host.isEmpty()) {
-        sshCommand += data.host;
+        
+        if (!data.host.isEmpty()) {
+            sshCommand += data.host;
+        }
     }
 
     controller->session()->sendTextToTerminal(sshCommand, QLatin1Char('\r'));


### PR DESCRIPTION
This shall fix a minor bug calling hosts that are defined in ~/.ssh/config by their profile name rather than its HostName.

    Definition:
    "profile name" is called Host in .ssh/config.

Example config in ~/.ssh/config:

 Host core
   HostName core.company.com
   User sshadmin

You want Konsole to run "ssh Host" or "ssh core", while
currently Konsole runs "ssh HostName" or "ssh core.company.com".
In the end it does not match any entity in ssh's config.

That error I think is laying in sshmanagerplugin.cpp:205-216
where we need to evolve the if statement.

Let me know in case something needs to be aligned with your requirements.
I am new to sw dev and this is my very first patch to a KDE or any cpp/Qt project.
